### PR TITLE
fix: remove explicit login button width

### DIFF
--- a/src/components/layout/TheSiteHeader.vue
+++ b/src/components/layout/TheSiteHeader.vue
@@ -93,7 +93,7 @@ function toggleMenu(input?: Event | boolean) {
       </template>
     </ul>
     <div
-      class="ml-2 mr-1 flex md:gap-2 w-16 flex-shrink-0 items-center justify-between"
+      class="ml-2 mr-1 flex md:gap-2 flex-shrink-0 items-center justify-between"
     >
       <div
         v-if="$auth.status === 'pending'"


### PR DESCRIPTION
This PR will fix this issue dark/Light toggle button half visible.
![Screenshot 2023-10-24 at 23 09 56](https://github.com/danielroe/roe.dev/assets/3233370/ed3f3e7f-997b-497c-a4d3-b9200e9442e2)
