### PR TITLE
fix: avoid flash or non-reponsiveness of color mode toggle button using the ColorScheme component

### DIFF
--- a/src/components/ToggleColorMode.vue
+++ b/src/components/ToggleColorMode.vue
@@ -4,11 +4,7 @@
       aria-label="Change site theme"
       type="button"
       class="h-7 w-12 relative rounded-full bg-accent ml-2 items-center justify-start px-1 transition-opacity outline-none border-2 border-solid border-accent hover:border-primary focus:border-primary active:border-primary"
-      @click="
-        $colorMode.value === 'dark'
-          ? ($colorMode.preference = 'light')
-          : ($colorMode.preference = 'dark')
-      "
+      @click="$colorMode.preference = $colorMode.value === 'dark' ? 'light' : 'dark'"
     >
       <span
         :class="['absolute -top-[50%] translate-y-[100%] inline-block rounded-full h-4 w-4 bg-primary transition-transform', $colorMode.value === 'dark' ? '-translate-x-4.5': 'translate-x-0.5']"

--- a/src/components/ToggleColorMode.vue
+++ b/src/components/ToggleColorMode.vue
@@ -1,7 +1,3 @@
-<script setup lang="ts">
-const colorMode = useColorMode()
-</script>
-
 <template>
   <ColorScheme placeholder="...">
     <button
@@ -9,16 +5,13 @@ const colorMode = useColorMode()
       type="button"
       class="h-7 w-12 relative rounded-full bg-accent ml-2 items-center justify-start px-1 transition-opacity outline-none border-2 border-solid border-accent hover:border-primary focus:border-primary active:border-primary"
       @click="
-        colorMode.value === 'dark'
-          ? (colorMode.preference = 'light')
-          : (colorMode.preference = 'dark')
+        $colorMode.value === 'dark'
+          ? ($colorMode.preference = 'light')
+          : ($colorMode.preference = 'dark')
       "
     >
       <span
-        class="inline-block rounded-full h-4 w-4 bg-primary transition-transform"
-        :style="
-          colorMode.value === 'light' ? 'transform:translateX(1.25rem)' : ''
-        "
+        :class="['absolute -top-[50%] translate-y-[100%] inline-block rounded-full h-4 w-4 bg-primary transition-transform', $colorMode.value === 'dark' ? '-translate-x-4.5': 'translate-x-0.5']"
       />
     </button>
   </ColorScheme>

--- a/src/components/ToggleColorMode.vue
+++ b/src/components/ToggleColorMode.vue
@@ -1,14 +1,17 @@
+<script setup lang="ts">
+const colorMode = useColorMode()
+</script>
+
 <template>
-  <ColorScheme placeholder="...">
-    <button
-      aria-label="Change site theme"
-      type="button"
-      class="h-7 w-12 relative rounded-full bg-accent ml-2 items-center justify-start px-1 transition-opacity outline-none border-2 border-solid border-accent hover:border-primary focus:border-primary active:border-primary"
-      @click="$colorMode.preference = $colorMode.value === 'dark' ? 'light' : 'dark'"
-    >
-      <span
-        :class="['absolute -top-[50%] translate-y-[100%] inline-block rounded-full h-4 w-4 bg-primary transition-transform', $colorMode.value === 'dark' ? '-translate-x-4.5': 'translate-x-0.5']"
-      />
-    </button>
-  </ColorScheme>
+  <button
+    v-if="colorMode"
+    aria-label="Change site theme"
+    type="button"
+    class="h-7 w-12 relative rounded-full bg-accent ml-2 items-center justify-start px-1 transition-opacity outline-none border-2 border-solid border-accent hover:border-primary focus:border-primary active:border-primary"
+    @click="colorMode.preference = colorMode.value === 'dark' ? 'light' : 'dark'"
+  >
+    <span
+      class="inline-block rounded-full h-4 w-4 bg-primary transition-transform light:translate-x-5"
+    />
+  </button>
 </template>

--- a/src/components/ToggleColorMode.vue
+++ b/src/components/ToggleColorMode.vue
@@ -3,22 +3,23 @@ const colorMode = useColorMode()
 </script>
 
 <template>
-  <button
-    v-if="colorMode"
-    aria-label="Change site theme"
-    type="button"
-    class="h-7 w-12 relative rounded-full bg-accent ml-2 items-center justify-start px-1 transition-opacity outline-none border-2 border-solid border-accent hover:border-primary focus:border-primary active:border-primary"
-    @click="
-      colorMode.value === 'dark'
-        ? (colorMode.preference = 'light')
-        : (colorMode.preference = 'dark')
-    "
-  >
-    <span
-      class="inline-block rounded-full h-4 w-4 bg-primary transition-transform"
-      :style="
-        colorMode.value === 'light' ? 'transform:translateX(1.25rem)' : ''
+  <ColorScheme placeholder="...">
+    <button
+      aria-label="Change site theme"
+      type="button"
+      class="h-7 w-12 relative rounded-full bg-accent ml-2 items-center justify-start px-1 transition-opacity outline-none border-2 border-solid border-accent hover:border-primary focus:border-primary active:border-primary"
+      @click="
+        colorMode.value === 'dark'
+          ? (colorMode.preference = 'light')
+          : (colorMode.preference = 'dark')
       "
-    />
-  </button>
+    >
+      <span
+        class="inline-block rounded-full h-4 w-4 bg-primary transition-transform"
+        :style="
+          colorMode.value === 'light' ? 'transform:translateX(1.25rem)' : ''
+        "
+      />
+    </button>
+  </ColorScheme>
 </template>


### PR DESCRIPTION

according to the [nuxt-color-mode docs](https://color-mode.nuxtjs.org/#caveats), without the `ColorMode` component, there will be either a flash or non-responsiveness of the color mode toggle button because the package is yet to determine the system's color theme and this behavior is as so on the live env:

https://github.com/danielroe/roe.dev/assets/44336070/515c36fa-fc09-4446-a68f-e02aef6927a9

## current behavior 👇🏽
https://github.com/danielroe/roe.dev/assets/44336070/03b7200a-2019-48d2-ab76-6973ce7b3233



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the color mode toggle feature for improved usability and visual appeal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->