### PR TITLE
perf: only include content endpoints for prerender

### DIFF
--- a/modules/content.ts
+++ b/modules/content.ts
@@ -1,0 +1,21 @@
+import { defineNuxtModule, useNuxt } from 'nuxt/kit'
+
+export default defineNuxtModule({
+  meta: {
+    name: 'nuxt-content-purge',
+  },
+  setup () {
+    const nuxt = useNuxt()
+    nuxt.hook('modules:done', () => {
+      const purgedHandlers: any[] = []
+      nuxt.hook('nitro:init', nitro => {
+        for (const handler of nitro.options.handlers!) {
+          if (handler?.route && /\/api\/_(content|mdc)/.test(handler.route)) {
+            purgedHandlers.push(handler)
+          }
+        }
+        nitro.options.handlers = nitro.options.handlers!.filter(handler => !purgedHandlers.includes(handler))
+      })
+    })
+  },
+})

--- a/modules/content.ts
+++ b/modules/content.ts
@@ -6,6 +6,7 @@ export default defineNuxtModule({
   },
   setup () {
     const nuxt = useNuxt()
+    if (nuxt.options.dev) return
     nuxt.hook('modules:done', () => {
       const purgedHandlers: any[] = []
       nuxt.hook('nitro:init', nitro => {

--- a/test/unit/bundle.spec.ts
+++ b/test/unit/bundle.spec.ts
@@ -79,12 +79,12 @@ describe('project sizes', () => {
     stats.server = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
     expect
       .soft(roundToKilobytes(stats.server.totalBytes))
-      .toMatchInlineSnapshot(`"713k"`)
+      .toMatchInlineSnapshot(`"621k"`)
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect
       .soft(roundToKilobytes(modules.totalBytes))
-      .toMatchInlineSnapshot(`"7510k"`)
+      .toMatchInlineSnapshot(`"7453k"`)
 
     const packages = modules.files
       .filter(m => m.endsWith('package.json'))
@@ -152,7 +152,6 @@ describe('project sizes', () => {
         "is-plain-obj",
         "iso-datestring-validator",
         "js-yaml",
-        "json5",
         "longest-streak",
         "lru-cache",
         "lru-cache/dist/esm",
@@ -213,7 +212,6 @@ describe('project sizes', () => {
         "scule",
         "shiki",
         "skin-tone",
-        "slugify",
         "source-map-js",
         "space-separated-tokens",
         "stringify-entities",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `nuxt-content-purge` module to enhance content management by purging specific API handlers, optimizing server performance and security.
  
- **Bug Fixes**
	- Updated expected test output for server and module sizes to reflect current project state after optimizations.

- **Chores**
	- Removed certain package names from size analysis tests, indicating potential exclusion from the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->