### PR TITLE
fix: allow images from github

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -290,7 +290,7 @@ export default defineNuxtConfig({
       crossOriginEmbedderPolicy: false,
       contentSecurityPolicy: {
         'script-src-attr': ['\'self\'', '\'unsafe-inline\''],
-        'img-src': ['\'self\'', 'data:', 'https://avatars.githubusercontent.com', 'https://raw.githubusercontent.com']
+        'img-src': ['\'self\'', 'data:', 'https://avatars.githubusercontent.com', 'https://raw.githubusercontent.com'],
       },
     },
   },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -290,7 +290,7 @@ export default defineNuxtConfig({
       crossOriginEmbedderPolicy: false,
       contentSecurityPolicy: {
         'script-src-attr': ['\'self\'', '\'unsafe-inline\''],
-        'img-src': ['\'self\'', 'data:', 'https://avatars.githubusercontent.com']
+        'img-src': ['\'self\'', 'data:', 'https://avatars.githubusercontent.com', 'https://raw.githubusercontent.com']
       },
     },
   },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -290,7 +290,7 @@ export default defineNuxtConfig({
       crossOriginEmbedderPolicy: false,
       contentSecurityPolicy: {
         'script-src-attr': ['\'self\'', '\'unsafe-inline\''],
-        'img-src': ["'self'", "data:", "https://avatars.githubusercontent.com"]
+        'img-src': ['\'self\'', 'data:', 'https://avatars.githubusercontent.com']
       },
     },
   },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -290,6 +290,7 @@ export default defineNuxtConfig({
       crossOriginEmbedderPolicy: false,
       contentSecurityPolicy: {
         'script-src-attr': ['\'self\'', '\'unsafe-inline\''],
+        'img-src': ["'self'", "data:", "https://avatars.githubusercontent.com"]
       },
     },
   },


### PR DESCRIPTION
When logging into GitHub on your website, nuxt-security block the user avatar loaded from GitHub.

```
Content-Security-Policy: The page’s settings blocked the loading of a resource (img-src) at https://avatars.githubusercontent.com/u/12418495?u=e4330319f80d59b8a30c696591d39c3429f04fae&v=4 because it violates the following directive: “img-src 'self' data:”
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced security measures by updating image source policies in the application.
	- Allowed images from the same origin, data URLs, and specific GitHub avatars.

- **Bug Fixes**
	- Improved overall security configuration to prevent potential vulnerabilities related to content injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->