### PR TITLE
chore: prefer `nuxt` over `nuxi`

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -24,7 +24,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Update blogs on dev.to
-        run: pnpm nuxi prepare
+        run: pnpm nuxt prepare
         env:
           DEVTO_TOKEN: ${{ secrets.DEVTO_TOKEN }}
           SYNC_DEV_TO: true

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:style": "stylelint **/*.{vue,css} --fix --ignore-path .gitignore",
     "lint": "pnpm lint:js && pnpm lint:style",
     "test": "vitest run test/unit/behaviour && vitest run test/unit/bundle && vitest run test/nuxt --config vitest.nuxt.config.mts",
-    "test:types": "nuxi prepare && vue-tsc --noEmit",
+    "test:types": "nuxt prepare && vue-tsc --noEmit",
     "test:e2e": "playwright test test/e2e",
     "test:e2e:update": "docker run --rm --network host -v $(pwd):/work/ -v /tmp/playwright-nm:/work/node_modules -w /work/ -it mcr.microsoft.com/playwright:v1.52.0-noble bash -c 'corepack enable && pnpm i && pnpm playwright test test/e2e --update-snapshots'",
     "postinstall": "nuxt prepare && pnpm simple-git-hooks install"


### PR DESCRIPTION

this follows up on https://github.com/nuxt/nuxt/pull/32237 to use `nuxt` command consistently now that we no longer need compatibility with nuxt 2.