### PR TITLE
chore: ignore builds by default

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,24 +1,21 @@
 packages:
   - cms
 
-ignoreDepScripts: true
-
 ignoreWorkspaceRootCheck: true
 
 overrides:
   vite: 8.0.13
 
-allowBuilds:
-  # -> ignore these builds
-  '@parcel/watcher': false
-  esbuild: false
-  unrs-resolver: false
-  workerd: false
-  # -> build these
-  better-sqlite3: true
-  sharp: true
-  simple-git-hooks: true
-  
 savePrefix: ''
 
 shellEmulator: true
+
+allowBuilds:
+  '*': false
+  '@parcel/watcher': false
+  better-sqlite3: true
+  esbuild: false
+  sharp: true
+  simple-git-hooks: true
+  unrs-resolver: false
+  workerd: false


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`